### PR TITLE
Improve portfolio descriptions and services

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="description"
-        content="Alejandro Vinokur - Full Stack Developer specializing in PHP, Laravel, JS, MySQL, PostgreSQL, MongoDB, Python, Web Scraping, API REST, and SOAP.">
+        content="Alejandro Vinokur - Full Stack Developer delivering scalable PHP & Python solutions, microservices, Docker, AWS, and AI integrations with OpenAI, DocumentAI and Google Vision AI.">
     <meta name="author" content="Alejandro Vinokur">
     <title>AleVinokur</title>
     <!-- font icons -->
@@ -351,18 +351,32 @@
                         </div>
                     </div>
                 </div>
-                <!-- Web Scraping and Automation -->
+                <!-- Web Scraping -->
                 <div class="col-md-4 col-sm-6">
                     <div class="card mb-5">
                         <div class="card-header has-icon">
                             <i class="ti-vector text-danger" aria-hidden="true"></i>
                         </div>
                         <div class="card-body px-4 py-3">
-                            <h5 class="mb-3 card-title text-dark">Web Scraping and Automation</h5>
+                            <h5 class="mb-3 card-title text-dark">Web Scraping</h5>
                             <p class="subtitle">
-                                Expertise in building web scrapers and automation scripts using Python and modern tools
-                                like Puppeteer and BeautifulSoup. I deliver data extraction solutions to streamline
-                                workflows and optimize decision-making.
+                                Expertise in building web scrapers using Python with Playwright or Puppeteer. I deliver
+                                data extraction solutions that streamline decision-making.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                <!-- Task Automation -->
+                <div class="col-md-4 col-sm-6">
+                    <div class="card mb-5">
+                        <div class="card-header has-icon">
+                            <i class="ti-loop text-danger" aria-hidden="true"></i>
+                        </div>
+                        <div class="card-body px-4 py-3">
+                            <h5 class="mb-3 card-title text-dark">Task Automation</h5>
+                            <p class="subtitle">
+                                Automation services integrating AI models with Python and LangChain to simplify
+                                repetitive workflows and improve productivity.
                             </p>
                         </div>
                     </div>
@@ -383,17 +397,17 @@
                         </div>
                     </div>
                 </div>
-                <!-- Cloud Solutions and Deployment -->
+                <!-- AI Integration -->
                 <div class="col-md-4 col-sm-6">
                     <div class="card mb-5">
                         <div class="card-header has-icon">
-                            <i class="ti-cloud text-danger" aria-hidden="true"></i>
+                            <i class="ti-light-bulb text-danger" aria-hidden="true"></i>
                         </div>
                         <div class="card-body px-4 py-3">
-                            <h5 class="mb-3 card-title text-dark">Cloud Solutions and Deployment</h5>
+                            <h5 class="mb-3 card-title text-dark">AI Integration</h5>
                             <p class="subtitle">
-                                I provide cloud-based deployment solutions, leveraging AWS EC2 and Docker to ensure your
-                                applications are reliable, efficient, and ready for scaling as your business grows.
+                                Integrating AI services with Python and LangChain. I utilize OpenAI models, DocumentAI and
+                                Google Vision AI to automate processes and extract meaningful insights.
                             </p>
                         </div>
                     </div>
@@ -485,10 +499,10 @@
                                 <div class="text-holder">
                                     <h6 class="title">Student Tracking</h6>
                                     <p class="subtitle" style="display: none;">
-                                        Implemented a digital system for recording student performance, attendance, and achievements, helping educators analyze trends and identify areas for improvement.
+                                        Developed a Laravel application using Hexagonal Architecture to monitor performance, attendance and achievements. Provided RESTful endpoints for third-party integration and leveraged PostgreSQL for reliable storage.
                                     </p>
                                     <p class="subtitle" style="display: none;">
-                                        <strong>Key Features:</strong> Real-time analytics, secure storage of student records, and customizable reporting.<br>
+                                        <strong>Key Features:</strong> Real-time analytics, secure record management, customizable reports.<br>
                                         <strong>Technologies:</strong> Laravel, PostgreSQL, Bootstrap.
                                     </p>
                                     <a href="#" class="btn btn-primary btn-sm mt-2">Read More</a>
@@ -507,11 +521,11 @@
                                 <div class="text-holder">
                                     <h6 class="title">Raffle System</h6>
                                     <p class="subtitle" style="display: none;">
-                                        Designed a dynamic raffle system that allows companies to create, manage, and analyze sweepstakes campaigns, increasing customer engagement.
+                                        Built a Laravel microservice to create and manage sweepstake campaigns, boosting customer engagement through dynamic promotions.
                                     </p>
                                     <p class="subtitle" style="display: none;">
-                                        <strong>Key Features:</strong> Real-time winner selection, multi-language support, and fraud detection.<br>
-                                        <strong>Technologies:</strong> PHP, Laravel, Redis.
+                                        <strong>Key Features:</strong> Real-time winner selection, multi-language support, fraud detection.<br>
+                                        <strong>Technologies:</strong> PHP, Laravel.
                                     </p>
                                     <a href="#" class="btn btn-primary btn-sm mt-2">Read More</a>
                                 </div>
@@ -527,10 +541,10 @@
                                 <div class="text-holder">
                                     <h6 class="title">Loyalty Program</h6>
                                     <p class="subtitle" style="display: none;">
-                                        Built a system that converts invoices into reward points redeemable through a personalized catalog, enhancing customer retention.
+                                        Created a loyalty platform converting invoices into reward points through a RESTful API and Redis-backed asynchronous queues.
                                     </p>
                                     <p class="subtitle" style="display: none;">
-                                        <strong>Key Features:</strong> Point calculation engine, user-friendly dashboard, and customizable reward catalogs.<br>
+                                        <strong>Key Features:</strong> Point calculation engine, catalog management dashboard, customizable rewards.<br>
                                         <strong>Technologies:</strong> Laravel, JavaScript, MySQL.
                                     </p>
                                     <a href="#" class="btn btn-primary btn-sm mt-2">Read More</a>
@@ -549,11 +563,11 @@
                                 <div class="text-holder">
                                     <h6 class="title">Web Scraping</h6>
                                     <p class="subtitle" style="display: none;">
-                                        Automated web scraping solutions to gather data from complex websites, bypassing security mechanisms and ensuring high data accuracy.
+                                        Engineered automated scraping services using Python, Playwright and FastAPI. Dockerized scripts leverage Redis queues to bypass Cloudflare, sanitize data and expose results via REST API.
                                     </p>
                                     <p class="subtitle" style="display: none;">
-                                        <strong>Key Features:</strong> Cloudflare bypassing, data cleaning pipelines, and real-time scraping.<br>
-                                        <strong>Technologies:</strong> Python, Playwright, FastAPI.
+                                        <strong>Key Features:</strong> Cloudflare bypass, data cleaning pipelines, real-time scraping via Redis queues.<br>
+                                        <strong>Technologies:</strong> Python, Playwright, FastAPI, Redis.
                                     </p>
                                     <a href="#" class="btn btn-primary btn-sm mt-2">Read More</a>
                                 </div>
@@ -571,11 +585,11 @@
                                 <div class="text-holder">
                                     <h6 class="title">Recruitment Platform</h6>
                                     <p class="subtitle" style="display: none;">
-                                        Developed an HR tool integrating ChatGPT API for automated candidate screening, enhancing hiring efficiency.
+                                        Designed a recruitment tool that integrates the OpenAI API with multiple models for automated candidate screening and evaluation.
                                     </p>
                                     <p class="subtitle" style="display: none;">
-                                        <strong>Key Features:</strong> Candidate matching algorithms, AI-driven recommendations, and interview scheduling.<br>
-                                        <strong>Technologies:</strong> PHP, ChatGPT API, PostgreSQL.
+                                        <strong>Key Features:</strong> Candidate matching algorithms, AI-driven recommendations, interview scheduling with event-driven services.<br>
+                                        <strong>Technologies:</strong> PHP, OpenAI API, PostgreSQL.
                                     </p>
                                     <a href="#" class="btn btn-primary btn-sm mt-2">Read More</a>
                                 </div>
@@ -593,11 +607,11 @@
                                 <div class="text-holder">
                                     <h6 class="title">Back Office Platform</h6>
                                     <p class="subtitle" style="display: none;">
-                                        Designed an administrative dashboard for managing company operations, streamlining tasks, and visualizing key metrics.
+                                        Implemented a secure dashboard for managing business operations and metrics using Laravel.
                                     </p>
                                     <p class="subtitle" style="display: none;">
-                                        <strong>Key Features:</strong> Customizable widgets, real-time reporting, and secure user authentication.<br>
-                                        <strong>Technologies:</strong> Laravel, JavaScript, Redis.
+                                        <strong>Key Features:</strong> Customizable widgets, real-time reporting, JWT authentication.<br>
+                                        <strong>Technologies:</strong> Laravel, JavaScript.
                                     </p>
                                     <a href="#" class="btn btn-primary btn-sm mt-2">Read More</a>
                                 </div>
@@ -613,10 +627,10 @@
                                 <div class="text-holder">
                                     <h6 class="title">Intranet System</h6>
                                     <p class="subtitle" style="display: none;">
-                                        Centralized tool for managing internal workflows, communications, and resource allocation for medium-sized enterprises.
+                                        Developed an intranet solution with Laravel and React.js backed by MongoDB to manage internal workflows and communications.
                                     </p>
                                     <p class="subtitle" style="display: none;">
-                                        <strong>Key Features:</strong> Document sharing, task management, and employee directory.<br>
+                                        <strong>Key Features:</strong> Document sharing, task management, employee directory, corporate authentication integration.<br>
                                         <strong>Technologies:</strong> Laravel, React.js, MongoDB.
                                     </p>
                                     <a href="#" class="btn btn-primary btn-sm mt-2">Read More</a>

--- a/resources/views/index.html
+++ b/resources/views/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="description"
-        content="Alejandro Vinokur - Full Stack Developer specializing in PHP, Laravel, JS, MySQL, PostgreSQL, MongoDB, Python, Web Scraping, API REST, and SOAP.">
+        content="Alejandro Vinokur - Full Stack Developer delivering scalable PHP & Python solutions, microservices, Docker, AWS, and AI integrations with OpenAI, DocumentAI and Google Vision AI.">
     <meta name="author" content="Alejandro Vinokur">
     <title>AleVinokur</title>
     <!-- font icons -->
@@ -352,18 +352,32 @@
                         </div>
                     </div>
                 </div>
-                <!-- Web Scraping and Automation -->
+                <!-- Web Scraping -->
                 <div class="col-md-4 col-sm-6">
                     <div class="card mb-5">
                         <div class="card-header has-icon">
                             <i class="ti-vector text-danger" aria-hidden="true"></i>
                         </div>
                         <div class="card-body px-4 py-3">
-                            <h5 class="mb-3 card-title text-dark">Web Scraping and Automation</h5>
+                            <h5 class="mb-3 card-title text-dark">Web Scraping</h5>
                             <p class="subtitle">
-                                Expertise in building web scrapers and automation scripts using Python and modern tools
-                                like Puppeteer and BeautifulSoup. I deliver data extraction solutions to streamline
-                                workflows and optimize decision-making.
+                                Expertise in building web scrapers using Python with Playwright or Puppeteer. I deliver
+                                data extraction solutions that streamline decision-making.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                <!-- Task Automation -->
+                <div class="col-md-4 col-sm-6">
+                    <div class="card mb-5">
+                        <div class="card-header has-icon">
+                            <i class="ti-loop text-danger" aria-hidden="true"></i>
+                        </div>
+                        <div class="card-body px-4 py-3">
+                            <h5 class="mb-3 card-title text-dark">Task Automation</h5>
+                            <p class="subtitle">
+                                Automation services integrating AI models with Python and LangChain to simplify
+                                repetitive workflows and improve productivity.
                             </p>
                         </div>
                     </div>
@@ -384,17 +398,17 @@
                         </div>
                     </div>
                 </div>
-                <!-- Cloud Solutions and Deployment -->
+                <!-- AI Integration -->
                 <div class="col-md-4 col-sm-6">
                     <div class="card mb-5">
                         <div class="card-header has-icon">
-                            <i class="ti-cloud text-danger" aria-hidden="true"></i>
+                            <i class="ti-light-bulb text-danger" aria-hidden="true"></i>
                         </div>
                         <div class="card-body px-4 py-3">
-                            <h5 class="mb-3 card-title text-dark">Cloud Solutions and Deployment</h5>
+                            <h5 class="mb-3 card-title text-dark">AI Integration</h5>
                             <p class="subtitle">
-                                I provide cloud-based deployment solutions, leveraging AWS EC2 and Docker to ensure your
-                                applications are reliable, efficient, and ready for scaling as your business grows.
+                                Integrating AI services with Python and LangChain. I utilize OpenAI models, DocumentAI and
+                                Google Vision AI to automate processes and extract meaningful insights.
                             </p>
                         </div>
                     </div>
@@ -486,10 +500,10 @@
                                 <div class="text-holder">
                                     <h6 class="title">Student Tracking</h6>
                                     <p class="subtitle" style="display: none;">
-                                        Implemented a digital system for recording student performance, attendance, and achievements, helping educators analyze trends and identify areas for improvement.
+                                        Developed a Laravel application using Hexagonal Architecture to monitor performance, attendance and achievements. Provided RESTful endpoints for third-party integration and leveraged PostgreSQL for reliable storage.
                                     </p>
                                     <p class="subtitle" style="display: none;">
-                                        <strong>Key Features:</strong> Real-time analytics, secure storage of student records, and customizable reporting.<br>
+                                        <strong>Key Features:</strong> Real-time analytics, secure record management, customizable reports.<br>
                                         <strong>Technologies:</strong> Laravel, PostgreSQL, Bootstrap.
                                     </p>
                                     <a href="#" class="btn btn-primary btn-sm mt-2">Read More</a>
@@ -508,11 +522,11 @@
                                 <div class="text-holder">
                                     <h6 class="title">Raffle System</h6>
                                     <p class="subtitle" style="display: none;">
-                                        Designed a dynamic raffle system that allows companies to create, manage, and analyze sweepstakes campaigns, increasing customer engagement.
+                                        Built a Laravel microservice to create and manage sweepstake campaigns, boosting customer engagement through dynamic promotions.
                                     </p>
                                     <p class="subtitle" style="display: none;">
-                                        <strong>Key Features:</strong> Real-time winner selection, multi-language support, and fraud detection.<br>
-                                        <strong>Technologies:</strong> PHP, Laravel, Redis.
+                                        <strong>Key Features:</strong> Real-time winner selection, multi-language support, fraud detection.<br>
+                                        <strong>Technologies:</strong> PHP, Laravel.
                                     </p>
                                     <a href="#" class="btn btn-primary btn-sm mt-2">Read More</a>
                                 </div>
@@ -528,10 +542,10 @@
                                 <div class="text-holder">
                                     <h6 class="title">Loyalty Program</h6>
                                     <p class="subtitle" style="display: none;">
-                                        Built a system that converts invoices into reward points redeemable through a personalized catalog, enhancing customer retention.
+                                        Created a loyalty platform converting invoices into reward points through a RESTful API and Redis-backed asynchronous queues.
                                     </p>
                                     <p class="subtitle" style="display: none;">
-                                        <strong>Key Features:</strong> Point calculation engine, user-friendly dashboard, and customizable reward catalogs.<br>
+                                        <strong>Key Features:</strong> Point calculation engine, catalog management dashboard, customizable rewards.<br>
                                         <strong>Technologies:</strong> Laravel, JavaScript, MySQL.
                                     </p>
                                     <a href="#" class="btn btn-primary btn-sm mt-2">Read More</a>
@@ -550,11 +564,11 @@
                                 <div class="text-holder">
                                     <h6 class="title">Web Scraping</h6>
                                     <p class="subtitle" style="display: none;">
-                                        Automated web scraping solutions to gather data from complex websites, bypassing security mechanisms and ensuring high data accuracy.
+                                        Engineered automated scraping services using Python, Playwright and FastAPI. Dockerized scripts leverage Redis queues to bypass Cloudflare, sanitize data and expose results via REST API.
                                     </p>
                                     <p class="subtitle" style="display: none;">
-                                        <strong>Key Features:</strong> Cloudflare bypassing, data cleaning pipelines, and real-time scraping.<br>
-                                        <strong>Technologies:</strong> Python, Playwright, FastAPI.
+                                        <strong>Key Features:</strong> Cloudflare bypass, data cleaning pipelines, real-time scraping via Redis queues.<br>
+                                        <strong>Technologies:</strong> Python, Playwright, FastAPI, Redis.
                                     </p>
                                     <a href="#" class="btn btn-primary btn-sm mt-2">Read More</a>
                                 </div>
@@ -572,11 +586,11 @@
                                 <div class="text-holder">
                                     <h6 class="title">Recruitment Platform</h6>
                                     <p class="subtitle" style="display: none;">
-                                        Developed an HR tool integrating ChatGPT API for automated candidate screening, enhancing hiring efficiency.
+                                        Designed a recruitment tool that integrates the OpenAI API with multiple models for automated candidate screening and evaluation.
                                     </p>
                                     <p class="subtitle" style="display: none;">
-                                        <strong>Key Features:</strong> Candidate matching algorithms, AI-driven recommendations, and interview scheduling.<br>
-                                        <strong>Technologies:</strong> PHP, ChatGPT API, PostgreSQL.
+                                        <strong>Key Features:</strong> Candidate matching algorithms, AI-driven recommendations, interview scheduling with event-driven services.<br>
+                                        <strong>Technologies:</strong> PHP, OpenAI API, PostgreSQL.
                                     </p>
                                     <a href="#" class="btn btn-primary btn-sm mt-2">Read More</a>
                                 </div>
@@ -594,11 +608,11 @@
                                 <div class="text-holder">
                                     <h6 class="title">Back Office Platform</h6>
                                     <p class="subtitle" style="display: none;">
-                                        Designed an administrative dashboard for managing company operations, streamlining tasks, and visualizing key metrics.
+                                        Implemented a secure dashboard for managing business operations and metrics using Laravel.
                                     </p>
                                     <p class="subtitle" style="display: none;">
-                                        <strong>Key Features:</strong> Customizable widgets, real-time reporting, and secure user authentication.<br>
-                                        <strong>Technologies:</strong> Laravel, JavaScript, Redis.
+                                        <strong>Key Features:</strong> Customizable widgets, real-time reporting, JWT authentication.<br>
+                                        <strong>Technologies:</strong> Laravel, JavaScript.
                                     </p>
                                     <a href="#" class="btn btn-primary btn-sm mt-2">Read More</a>
                                 </div>
@@ -614,10 +628,10 @@
                                 <div class="text-holder">
                                     <h6 class="title">Intranet System</h6>
                                     <p class="subtitle" style="display: none;">
-                                        Centralized tool for managing internal workflows, communications, and resource allocation for medium-sized enterprises.
+                                        Developed an intranet solution with Laravel and React.js backed by MongoDB to manage internal workflows and communications.
                                     </p>
                                     <p class="subtitle" style="display: none;">
-                                        <strong>Key Features:</strong> Document sharing, task management, and employee directory.<br>
+                                        <strong>Key Features:</strong> Document sharing, task management, employee directory, corporate authentication integration.<br>
                                         <strong>Technologies:</strong> Laravel, React.js, MongoDB.
                                     </p>
                                     <a href="#" class="btn btn-primary btn-sm mt-2">Read More</a>


### PR DESCRIPTION
## Summary
- refine portfolio meta description with AI integration
- update project sections to limit Redis mentions and reference OpenAI API
- introduce separate Task Automation card and new AI Integration service
- fix descriptions for raffle, loyalty, web scraping, recruitment, and back office

## Testing
- `composer install`
- `./vendor/bin/phpunit` *(fails: MissingAppKeyException)*

------
https://chatgpt.com/codex/tasks/task_e_68821e56fc48832e95a720cfd4cf8191