### PR TITLE
chore: integrate GTM GTM-PHD6VZ8L

### DIFF
--- a/resources/views/components.blade.php
+++ b/resources/views/components.blade.php
@@ -11,9 +11,24 @@
    <link rel="stylesheet" href="assets/vendors/themify-icons/css/themify-icons.css">
    <!-- Bootstrap + Steller  -->
    <link rel="stylesheet" href="assets/css/johndoe.css">
+
+   <!-- Google Tag Manager -->
+   @production
+   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+   new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+   j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+   'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+   })(window,document,'script','dataLayer','GTM-PHD6VZ8L');</script>
+   @endproduction
+   <!-- End Google Tag Manager -->
 </head>
 <body>
-
+   <!-- Google Tag Manager (noscript) -->
+   @production
+   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PHD6VZ8L"
+   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+   @endproduction
+   <!-- End Google Tag Manager (noscript) -->
    <!-- Page Header -->
    <header class="header header-mini"> 
       <div class="header-title">Components</div> 


### PR DESCRIPTION
## Summary
- add Google Tag Manager GTM-PHD6VZ8L snippet in head and body

## Testing
- `./vendor/bin/phpunit` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c309556310832ea5d0a087288dd8fd